### PR TITLE
chore(llama.cpp): added the installation of libxcrypt-compat

### DIFF
--- a/playbooks/basic-llama.cpp.yml
+++ b/playbooks/basic-llama.cpp.yml
@@ -56,6 +56,7 @@
           - cmake
           - git
           - openblas-devel
+          - libxcrypt-compat
         state: latest
     
 - name: Micromamba setup


### PR DESCRIPTION
chore(llama.cpp): added the installation of libxcrypt-compat, which is not always present on RHEL (especially in IBM techzone).